### PR TITLE
Delete invalid option in 1 on 1 with notes

### DIFF
--- a/handoutWithNotes.sty
+++ b/handoutWithNotes.sty
@@ -404,7 +404,6 @@
     \edef\pgfpageoptionborder{0pt}
  }
  {
-    \setkeys{pgfpagesuselayoutoption}{portrait}
     \pgfpagesphysicalpageoptions
     {%
       logical pages=2,%


### PR DESCRIPTION
`portrait` is the default page orientation and is not a valid option.
Causes a keyval error when using the `1 on 1 with notes` page layout.